### PR TITLE
Add cross-platform Word automation

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,21 +1,20 @@
 using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+#if WINDOWS
 using Word = Microsoft.Office.Interop.Word;
+#endif
 
 class Program
 {
     /// <summary>
-    /// Launches Microsoft Word and types a sample letter to the editor
-    /// character by character to mimic user input.
+    /// Creates a sample letter using the available automation method for the
+    /// current platform. Windows uses COM Interop, macOS uses AppleScript, and
+    /// other platforms fall back to generating a text file.
     /// </summary>
     static void Main(string[] args)
     {
-        // Start Word and make it visible
-        var wordApp = new Word.Application();
-        wordApp.Visible = true;
-
-        // Create a new document
-        var document = wordApp.Documents.Add();
-
         string[] lines = new[]
         {
             "Dear Editor,",
@@ -27,14 +26,67 @@ class Program
             "A Concerned Reader"
         };
 
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            WriteLetterWindows(lines);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            WriteLetterMac(lines);
+        }
+        else
+        {
+            WriteLetterOther(lines);
+        }
+    }
+
+#if WINDOWS
+    static void WriteLetterWindows(string[] lines)
+    {
+        var wordApp = new Word.Application();
+        wordApp.Visible = true;
+        var document = wordApp.Documents.Add();
+
         foreach (var line in lines)
         {
             foreach (char c in line)
             {
                 wordApp.Selection.TypeText(c.ToString());
-                System.Threading.Thread.Sleep(50); // small delay to mimic typing
+                System.Threading.Thread.Sleep(50);
             }
             wordApp.Selection.TypeParagraph();
         }
+    }
+#endif
+
+    static void WriteLetterMac(string[] lines)
+    {
+        var scriptPath = Path.Combine(Path.GetTempPath(), "letter.scpt");
+        string joined = string.Join("\\n", lines).Replace("\"", "\\\"");
+
+        var script = string.Join('\n', new[]
+        {
+            "tell application \"Microsoft Word\"",
+            "activate",
+            "set newDoc to make new document",
+            $"set content of text object of newDoc to \"{joined}\"",
+            "end tell"
+        });
+
+        File.WriteAllText(scriptPath, script);
+        Process.Start("osascript", scriptPath);
+    }
+
+    static void WriteLetterOther(string[] lines)
+    {
+        string path = Path.Combine(Path.GetTempPath(), "letter.txt");
+        File.WriteAllLines(path, lines);
+
+        var psi = new ProcessStartInfo
+        {
+            FileName = path,
+            UseShellExecute = true
+        };
+        Process.Start(psi);
     }
 }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Feel free to use this project as a sandbox for trying out new tools, scripts, or
 - Flexible structure for adding new files or scripts
 - Suitable for workflow and automation experiments
 - Demonstrates automating Microsoft Word to compose a sample letter
+- Cross-platform support: COM automation on Windows, AppleScript on macOS, and plain text fallback elsewhere
 
 ## Getting Started
 

--- a/test.csproj
+++ b/test.csproj
@@ -7,7 +7,11 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <ItemGroup>
+    <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
+        <DefineConstants>WINDOWS</DefineConstants>
+    </PropertyGroup>
+
+    <ItemGroup Condition="'$(OS)' == 'Windows_NT'">
         <PackageReference Include="Microsoft.Office.Interop.Word" Version="15.0.4795.1000" />
     </ItemGroup>
 


### PR DESCRIPTION
## Summary
- handle Word automation on Windows, macOS and others
- document cross-platform support
- conditionally reference Office Interop only on Windows

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684095df9a44832aa9d1f0f8e8533006